### PR TITLE
215 gh actions test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
 
   call-tests-unit:
     name: Run Unit Tests
-    uses: eclipse-pass/pass-dupe-checker/.github/workflows/tests-unit.yml@main
+    uses: eclipse-pass/pass-dupe-checker/.github/workflows/tests-unit.yml@master
     
 #  call-tests-integration:
 #    name: Run Integration Tests
-#    uses: eclipse-pass/pass-dupe-checker/.github/workflows/tests-integration.yml@main
+#    uses: eclipse-pass/pass-dupe-checker/.github/workflows/tests-integration.yml@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: pass-docker-services Continuous Integration
+on: [ pull_request, workflow_dispatch ]
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  print-workflow-description:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "This is a CI build of branch ${{ github.ref }} in repository ${{ github.repository }}"
+      - run: echo "This job was triggered by a ${{ github.event_name }} event and is running on a ${{ runner.os }} server"
+
+  call-tests-unit:
+    name: Run Unit Tests
+    uses: eclipse-pass/pass-dupe-checker/.github/workflows/tests-unit.yml@main
+    
+#  call-tests-integration:
+#    name: Run Integration Tests
+#    uses: eclipse-pass/pass-dupe-checker/.github/workflows/tests-integration.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     name: Run Unit Tests
     uses: eclipse-pass/pass-dupe-checker/.github/workflows/tests-unit.yml@master
     
-#  call-tests-integration:
-#    name: Run Integration Tests
+  call-tests-integration:
+    name: Run Integration Tests
+    run: echo "There currently are no Integration Tests for eclipse-pass/pass-dupe-checker.\nSkipping..."
 #    uses: eclipse-pass/pass-dupe-checker/.github/workflows/tests-integration.yml@master

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -1,0 +1,18 @@
+name: Run Integration Tests
+on:
+  workflow_call
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.17.0'
+
+      - name: Run Integration Tests
+        run: go test -tags=integration ./...

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -1,0 +1,18 @@
+name: Run Unit Tests
+on:
+  workflow_call
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.17.0'
+
+      - name: Run Unit Tests
+        run: go test ./...

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -15,4 +15,4 @@ jobs:
           go-version: '>=1.17.0'
 
       - name: Run Unit Tests
-        run: go test
+        run: go test ./...

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -15,4 +15,4 @@ jobs:
           go-version: '>=1.17.0'
 
       - name: Run Unit Tests
-        run: go test ./...
+        run: go test

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,8 @@
+Copyright 2022 Johns Hopkins University
+
+OA-PASS (Open Access – Public Access Submission System) code is licensed under the Apache License, Version 2.0 (the "License"); you may not use code in this repository except in compliance with the License.
+
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
+


### PR DESCRIPTION
Currently, the Unit tests (`.github/workflows/tests-unit.yml`) are run with `go test`. This succeeds but skips tests. Running `go test ./...` doesn't skip tests but fails.

I'm opening this PR to use `go test ./...`. It should be safe to merge once https://github.com/eclipse-pass/main/issues/263 has been closed.